### PR TITLE
Revise MBRGenerationConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ model = MBR(LlamaForCausalLM).from_pretrained(...)
 
 ### 2. Configure MBR decoding
 
-Create an `MBRGenerationConfig` object to pass to the model's `generate` method:
+Create an `MBRConfig` object to pass to the model's `generate` method:
 
 ```python
-from mbr import MBRGenerationConfig
+from mbr import MBRConfig
 
-mbr_config = MBRGenerationConfig(
+mbr_config = MBRConfig(
     num_samples=10,
     metric="chrf",
 )

--- a/experiments/bertsch-et-al-2023-mbr/run_experiment.py
+++ b/experiments/bertsch-et-al-2023-mbr/run_experiment.py
@@ -8,7 +8,7 @@ from datasets import load_dataset
 from tqdm import tqdm
 from transformers import BartForConditionalGeneration, AutoTokenizer, pipeline, GenerationConfig
 
-from mbr import MBR, MBRGenerationConfig
+from mbr import MBR, MBRConfig
 
 results_file = jsonlines.open(Path(__file__).parent / f"results.jsonl", "w")
 
@@ -26,7 +26,7 @@ evaluation_metric_rouge = evaluate.load("rouge")
 dataset = load_dataset("cnn_dailymail", "3.0.0", split="test")
 
 # MBR
-mbr_config = MBRGenerationConfig()
+mbr_config = MBRConfig()
 mbr_config.num_samples = 30
 mbr_config.num_references = 30
 mbr_config.metric = "rouge"

--- a/experiments/freitag-et-al-2023-epsilon/run_experiment.py
+++ b/experiments/freitag-et-al-2023-epsilon/run_experiment.py
@@ -10,7 +10,7 @@ from datasets import load_dataset
 from tqdm import tqdm
 from transformers import FSMTForConditionalGeneration, AutoTokenizer, pipeline, set_seed, GenerationConfig
 
-from mbr import MBR, MBRGenerationConfig
+from mbr import MBR, MBRConfig
 from mbr.metrics.comet import CometMetricRunner
 
 set_seed(42)
@@ -51,7 +51,7 @@ references = Path(ref_path).read_text().splitlines()
 assert len(dataset["test"]) == len(references)
 
 # MBR
-mbr_config = MBRGenerationConfig()
+mbr_config = MBRConfig()
 mbr_config.num_samples = 1024
 mbr_config.metric = "comet"
 mbr_config.metric_config_name = "eamt22-cometinho-da"

--- a/experiments/müller-sennrich-2021-understanding/run_experiment.py
+++ b/experiments/müller-sennrich-2021-understanding/run_experiment.py
@@ -6,10 +6,10 @@ import sacrebleu
 import torch
 from datasets import load_dataset
 from tqdm import tqdm
-from transformers import MarianMTModel, AutoTokenizer, pipeline, GenerationConfig, set_seed
+from transformers import MarianMTModel, AutoTokenizer, pipeline, set_seed
 from transformers.pipelines.base import KeyDataset
 
-from mbr import MBR, MBRGenerationConfig
+from mbr import MBR, MBRConfig
 
 set_seed(42)
 
@@ -52,7 +52,7 @@ dataset = load_dataset("Helsinki-NLP/tatoeba_mt", language_pair=language_pair)
 references = dataset["test"]["targetString"]
 
 # MBR
-mbr_config = MBRGenerationConfig()
+mbr_config = MBRConfig()
 mbr_config.metric = "chrf"
 mbr_config.metric_output_field = "score"
 batch_size = 64 if "-big-" in model_name else 256

--- a/src/mbr/__init__.py
+++ b/src/mbr/__init__.py
@@ -1,4 +1,4 @@
-from mbr.generation.configuration_utils import MBRGenerationConfig
+from mbr.generation.configuration_utils import MBRConfig
 from mbr.generation.utils import MBROutput, MBRGenerationMixin
 from mbr.metrics.base import MetricOutput, MetricRunner
 from mbr.modeling import MBR

--- a/src/mbr/generation/__init__.py
+++ b/src/mbr/generation/__init__.py
@@ -1,1 +1,0 @@
-MBR_GENERATION_CONFIG_NAME = "mbr_config.json"

--- a/src/mbr/generation/utils.py
+++ b/src/mbr/generation/utils.py
@@ -14,7 +14,7 @@ from transformers.generation.utils import GenerationMode
 from transformers.integrations.deepspeed import is_deepspeed_zero3_enabled
 from transformers.utils import logging, ModelOutput
 
-from mbr.generation.configuration_utils import MBRGenerationConfig
+from mbr.generation.configuration_utils import MBRConfig
 from mbr.metrics.base import MetricRunner, MetricOutput
 
 if TYPE_CHECKING:
@@ -62,7 +62,7 @@ class MBRGenerationMixin(GenerationMixin):
             inputs: Optional[torch.Tensor] = None,
             generation_config: Optional[GenerationConfig] = None,
             references_config: Optional[GenerationConfig] = None,
-            mbr_config: Optional[MBRGenerationConfig] = None,
+            mbr_config: Optional[MBRConfig] = None,
             tokenizer: Optional["PreTrainedTokenizer"] = None,
             metric_runner: Optional[MetricRunner] = None,
             logits_processor: Optional[LogitsProcessorList] = None,
@@ -107,11 +107,10 @@ class MBRGenerationMixin(GenerationMixin):
             references_config (`GenerationConfig`, *optional*):
                 The generation configuration to be used for the generation of pseudo-references.
                 If `None`, `generation_config` will be used.
-            mbr_config (`~mbr.generation.MBRGenerationConfig`, *optional*):
-                The generation configuration to be used as base parametrization for MBR decoding. If `None`, the
-                default will be used, which had the following loading priority: 1) from the `mbr_config.json` model
-                file, if it exists; 2) from the model configuration. Please note that unspecified parameters will
-                inherit [`~mbr.generation.MBRGenerationConfig`]'s default values.
+            mbr_config (`~mbr.generation.MBRConfig`, *optional*):
+                The generation configuration to be used as base parametrization for MBR decoding. If `None`, a default
+                configuration is used. Please note that unspecified parameters will inherit
+                [`~mbr.generation.MBRConfig`]'s default values.
             tokenizer (`PreTrainedTokenizer`, *optional*):
                 A tokenizer that can be used to convert the generated token ids to strings, which is usually
                 required for computing the metric.
@@ -182,8 +181,8 @@ class MBRGenerationMixin(GenerationMixin):
             raise ValueError(
                 f"`references_config` has to be of type `GenerationConfig`, but is {type(references_config)}"
             )
-        if mbr_config is not None and not isinstance(mbr_config, MBRGenerationConfig):
-            raise ValueError(f"`mbr_config` has to be of type `MBRGenerationConfig`, but is {type(mbr_config)}")
+        if mbr_config is not None and not isinstance(mbr_config, MBRConfig):
+            raise ValueError(f"`mbr_config` has to be of type `MBRConfig`, but is {type(mbr_config)}")
         if mbr_config is None:
             raise ValueError("`mbr_config` must be passed to `generate()`.")
         if tokenizer is None and metric_runner is None:

--- a/src/mbr/metrics/base.py
+++ b/src/mbr/metrics/base.py
@@ -9,7 +9,7 @@ from evaluate import EvaluationModule
 from transformers import PreTrainedTokenizerBase
 from transformers.utils import ModelOutput
 
-from mbr import MBRGenerationConfig
+from mbr import MBRConfig
 
 MetricType = Union[Metric, EvaluationModule]
 
@@ -35,7 +35,7 @@ class MetricRunner:
     features.
     """
 
-    def __init__(self, mbr_config: MBRGenerationConfig, tokenizer: PreTrainedTokenizerBase):
+    def __init__(self, mbr_config: MBRConfig, tokenizer: PreTrainedTokenizerBase):
         self.mbr_config = mbr_config
         # Ensure that mbr_config.metric_kwargs is hashable (because _compute_metric() uses lru_cache)
         if mbr_config.metric_kwargs:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,87 +1,11 @@
-"""
-Adapted from https://github.com/huggingface/transformers/blob/main/tests/generation/test_configuration_utils.py
-"""
-
-import copy
-import tempfile
 from unittest import TestCase
 
-from transformers import AutoConfig
-
-from mbr import MBRGenerationConfig
+from mbr import MBRConfig
 
 
-class GenerationConfigTest(TestCase):
+class MBRConfigTestCase(TestCase):
 
-    def test_save_load_config(self):
-        config = MBRGenerationConfig(
-            num_samples=100,
-            num_references=50,
-        )
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            config.save_pretrained(tmp_dir)
-            loaded_config = MBRGenerationConfig.from_pretrained(tmp_dir)
-
-        # Checks parameters that were specified
-        self.assertEqual(loaded_config.num_samples, 100)
-        self.assertEqual(loaded_config.num_references, 50)
-
-        # Checks parameters that were not specified (defaults)
-        self.assertEqual(loaded_config.metric , "chrf")
-
-    def test_from_model_config(self):
-        model_config = AutoConfig.from_pretrained("distilgpt2")
-        generation_config_from_model = MBRGenerationConfig.from_model_config(model_config)
-        self.assertIsInstance(generation_config_from_model, MBRGenerationConfig)
-
-    def test_update(self):
-        generation_config = MBRGenerationConfig()
-        update_kwargs = {
-            "num_samples": 200,
-            "foo": "bar",
-        }
-        update_kwargs_copy = copy.deepcopy(update_kwargs)
-        unused_kwargs = generation_config.update(**update_kwargs)
-
-        # update_kwargs was not modified (no side effects)
-        self.assertEqual(update_kwargs, update_kwargs_copy)
-
-        # update_kwargs was used to update the config on valid attributes
-        self.assertEqual(generation_config.num_samples, 200)
-
-        # `.update()` returns a dictionary of unused kwargs
-        self.assertEqual(unused_kwargs, {"foo": "bar"})
-
-    def test_initialize_new_kwargs(self):
-        generation_config = MBRGenerationConfig()
-        generation_config.foo = "bar"
-
-        with tempfile.TemporaryDirectory("test-generation-config") as tmp_dir:
-            generation_config.save_pretrained(tmp_dir)
-
-            new_config = MBRGenerationConfig.from_pretrained(tmp_dir)
-        # update_kwargs was used to update the config on valid attributes
-        self.assertEqual(new_config.foo, "bar")
-
-        generation_config = MBRGenerationConfig.from_model_config(new_config)
-        assert not hasattr(generation_config, "foo")  # no new kwargs should be initialized if from config
-
-    def test_kwarg_init(self):
-        """Tests that we can overwrite attributes at `from_pretrained` time."""
-        default_config = MBRGenerationConfig()
-        self.assertEqual(default_config.num_samples, 10)
-        self.assertEqual(default_config.num_references, 10)
-        config = MBRGenerationConfig(
-            num_samples=100,
-            num_references=50,
-        )
-        self.assertEqual(config.num_samples, 100)
-        self.assertEqual(config.num_references, 50)
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            config.save_pretrained(tmp_dir)
-            loaded_config = MBRGenerationConfig.from_pretrained(tmp_dir, num_samples=200)
-
-        self.assertEqual(loaded_config.num_samples, 200)
-        self.assertEqual(loaded_config.num_references, 50)
-        self.assertEqual(loaded_config.metric, "chrf")  # default value
+    def test_default_config(self):
+        config = MBRConfig()
+        self.assertEqual(config.num_samples, 10)
+        self.assertEqual(config.num_references, 10)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -6,7 +6,7 @@ import torch
 from transformers import AutoTokenizer, GPT2LMHeadModel, M2M100ForConditionalGeneration, GenerationConfig
 from transformers.generation import SampleDecoderOnlyOutput, SampleEncoderDecoderOutput
 
-from mbr import MBR, MBRGenerationConfig, MBROutput, MetricRunner, MetricOutput
+from mbr import MBR, MBRConfig, MBROutput, MetricRunner, MetricOutput
 
 
 class DecoderOnlyTestCase(TestCase):
@@ -16,7 +16,7 @@ class DecoderOnlyTestCase(TestCase):
         self.tokenizer = AutoTokenizer.from_pretrained("distilgpt2")
 
     def test_generate(self):
-        mbr_config = MBRGenerationConfig(
+        mbr_config = MBRConfig(
             num_samples=5,
         )
         input_sentences = [
@@ -35,7 +35,7 @@ class DecoderOnlyTestCase(TestCase):
         self.assertTrue(output[0].startswith("Hello, my name is"))
 
     def test_model_output(self):
-        mbr_config = MBRGenerationConfig(
+        mbr_config = MBRConfig(
             num_samples=5,
             return_dict_in_generate=True,
         )
@@ -59,7 +59,7 @@ class DecoderOnlyTestCase(TestCase):
         self.assertIsNone(output.metric_scores)
 
     def test_model_output_extended(self):
-        mbr_config = MBRGenerationConfig(
+        mbr_config = MBRConfig(
             num_samples=5,
             return_dict_in_generate=True,
             output_scores=True,
@@ -111,7 +111,7 @@ class DecoderOnlyTestCase(TestCase):
         self.assertEqual(1, len(sample.hidden_states[0][0]))
 
     def test_metric_runner(self):
-        mbr_config = MBRGenerationConfig(
+        mbr_config = MBRConfig(
             num_samples=5,
         )
         input_sentences = [
@@ -130,7 +130,7 @@ class DecoderOnlyTestCase(TestCase):
         self.assertTrue(output[0].startswith("Hello, my name is"))
 
     def test_generation_config(self):
-        mbr_config = MBRGenerationConfig(
+        mbr_config = MBRConfig(
             num_samples=5,
         )
         generation_config = GenerationConfig.from_pretrained("distilgpt2",
@@ -154,7 +154,7 @@ class DecoderOnlyTestCase(TestCase):
         self.assertTrue(output[0].startswith("Hello, my name is"))
 
     def test_references_config(self):
-        mbr_config = MBRGenerationConfig(
+        mbr_config = MBRConfig(
             num_samples=5,
         )
         generation_config = GenerationConfig.from_pretrained("distilgpt2",
@@ -193,7 +193,7 @@ class EncoderDecoderTestCase(TestCase):
         self.tokenizer.tgt_lang = "fr"
 
     def test_generate(self):
-        mbr_config = MBRGenerationConfig(
+        mbr_config = MBRConfig(
             num_samples=5,
         )
         input_sentences = [
@@ -212,7 +212,7 @@ class EncoderDecoderTestCase(TestCase):
         self.assertEqual(2, len(translations))
 
     def test_model_output(self):
-        mbr_config = MBRGenerationConfig(
+        mbr_config = MBRConfig(
             num_samples=5,
             return_dict_in_generate=True,
         )
@@ -236,7 +236,7 @@ class EncoderDecoderTestCase(TestCase):
         self.assertIsNone(output.metric_scores)
 
     def test_model_output_extended(self):
-        mbr_config = MBRGenerationConfig(
+        mbr_config = MBRConfig(
             num_samples=5,
             return_dict_in_generate=True,
             output_scores=True,

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -6,14 +6,14 @@ import evaluate
 import torch
 from transformers import AutoTokenizer
 
-from mbr import MetricRunner, MBRGenerationConfig
+from mbr import MetricRunner, MBRConfig
 from mbr.metrics import metric_is_source_based
 
 
 class MetricUtilsTestCase(TestCase):
 
     def setUp(self):
-        self.mbr_config = MBRGenerationConfig(
+        self.mbr_config = MBRConfig(
             metric="chrf",
             metric_output_field="score",
             num_samples=3,

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 
 from transformers import AutoTokenizer, pipeline, GPT2LMHeadModel, M2M100ForConditionalGeneration
 
-from mbr import MBRGenerationConfig
+from mbr import MBRConfig
 from mbr import MBR
 
 
@@ -16,7 +16,7 @@ class TextGenerationTestCase(TestCase):
         self.pipeline = pipeline("text-generation", model=self.model, tokenizer=self.tokenizer)
 
     def test_pipeline(self):
-        mbr_config = MBRGenerationConfig(
+        mbr_config = MBRConfig(
             num_samples=5,
         )
         output = self.pipeline(
@@ -38,7 +38,7 @@ class TranslationTestCase(TestCase):
         self.tokenizer.tgt_lang = "fr"
 
     def test_pipeline(self):
-        mbr_config = MBRGenerationConfig(
+        mbr_config = MBRConfig(
             num_samples=5,
         )
         output = self.pipeline(


### PR DESCRIPTION
- Remove `GenerationConfig` as parent class to avoid confusion with the `generation_config`, `references_config` objects passed to `generate()`, which also inherit from `GenerationConfig`
- Rename to `MBRConfig`