### PR TITLE
Revise metric cache

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "transformers",
     "evaluate",
     "sacrebleu",
+    "cachetools",
     "tqdm",
 ]
 classifiers = [

--- a/src/mbr/generation/configuration_utils.py
+++ b/src/mbr/generation/configuration_utils.py
@@ -40,6 +40,8 @@ class MBRConfig:
             Field of the metric output that is used
         metric_kwargs (optional):
             Additional arguments for the metric's `compute` method. The default MetricRunner requires it to be hashable.
+        metric_cache_size (`int`, *optional*, defaults to `num_samples` * `num_references`):
+            Size of the cache for the metric. Set to `None` to disable caching (not recommended).
         lower_is_better (`bool`, *optional*, defaults to `False`):
             Set to true if lower metric scores are better (e.g., perplexity).
 
@@ -73,6 +75,7 @@ class MBRConfig:
         self.metric_config_name = kwargs.pop("metric_config_name", None)
         self.metric_output_field = kwargs.pop("metric_output_field", "score")
         self.metric_kwargs = kwargs.pop("metric_kwargs", {})
+        self.metric_cache_size = kwargs.pop("metric_cache_size", self.num_samples * self.num_references)
         self.lower_is_better = kwargs.pop("lower_is_better", False)
 
         # Parameters that define the output variables of `generate`

--- a/src/mbr/metrics/base.py
+++ b/src/mbr/metrics/base.py
@@ -1,9 +1,9 @@
-import functools
 from dataclasses import dataclass
 from typing import Tuple, Union, List, Optional
 
 import evaluate
 import torch
+from cachetools.func import fifo_cache
 from datasets import Metric
 from evaluate import EvaluationModule
 from transformers import PreTrainedTokenizerBase
@@ -46,6 +46,7 @@ class MetricRunner:
         self.tokenizer = tokenizer
         self.metric = self._load_metric()
         self.metric_is_source_based = metric_is_source_based(self.metric)
+        self._compute_metric_cached = fifo_cache(maxsize=self.mbr_config.metric_cache_size)(self._compute_metric)
 
     def _load_metric(self) -> MetricType:
         metric = self.mbr_config.metric
@@ -117,14 +118,14 @@ class MetricRunner:
                 for k in range(self.mbr_config.num_references):
                     reference = references[k][i]
                     if inputs is not None:
-                        score = self._compute_metric(
+                        score = self.compute_metric(
                             sources=(inputs[i],),
                             predictions=(sample,),
                             references=(reference,),
                             **self.mbr_config.metric_kwargs,
                         )
                     else:
-                        score = self._compute_metric(
+                        score = self.compute_metric(
                             predictions=(sample,),
                             references=(reference,),
                             **self.mbr_config.metric_kwargs,
@@ -132,7 +133,6 @@ class MetricRunner:
                     metric_scores[i, j, k] = score
         return metric_scores
 
-    @functools.lru_cache(maxsize=(1024 ** 2))
     def _compute_metric(self, *args, **kwargs) -> float:
         # Call _compute() instead of compute() for performance reasons.
         # Since we are comparing individual samples, we do not need the overhead of compute().
@@ -146,6 +146,9 @@ class MetricRunner:
         if isinstance(score, list):
             score = score[0]
         return score
+
+    def compute_metric(self, *args, **kwargs) -> float:
+        return self._compute_metric_cached(*args, **kwargs)
 
 
 def metric_is_source_based(metric: MetricType) -> bool:


### PR DESCRIPTION
- Make cache size configurable via `MBRConfig.metric_cache_size`
- Use FIFO cache instead of LRU
- Extend caching to `CometMetricRunner` (this may be needed if the metric is called multiple times with similar inputs, e.g. for MBR with iterative pruning)
